### PR TITLE
Fix misprint in negative sigmoid formula

### DIFF
--- a/nlp_course/word_embeddings.html
+++ b/nlp_course/word_embeddings.html
@@ -888,7 +888,7 @@ for (i = 0; i < dropdown.length; i++) {
 
     <p>Note that
     \(\sigma(-x)=\frac{1}{1+e^{x}}=\frac{1\cdot e^{-x}}{(1+e^{x})\cdot e^{-x}} =
-    \frac{e^{-x}}{1+e^{-x}}= 1- \frac{1}{1+e^{x}}=1-\sigma(x)\). Then the loss can also be written as:
+    \frac{e^{-x}}{1+e^{-x}}= 1- \frac{1}{1+e^{-x}}=1-\sigma(x)\). Then the loss can also be written as:
     \[ J_{t,j}(\theta)=
     -\log\sigma(\color{#888}{u_{cute}^T}\color{#88bd33}{v_{cat}}\color{black}) -
     \sum\limits_{w\in \{w_{i_1},\dots, w_{i_K}\}}\log(1-\sigma({\color{#888}{u_w^T}\color{#88bd33}{v_{cat}}}\color{black})).


### PR DESCRIPTION
In Word Embeddings, chapter Faster Training: Negative Sampling formula for sigmoid(-x) has a typo: e^x instead of e^{-x} in the denominator. Fix it.